### PR TITLE
Correct swapping of long/lat. Added CRS to occurrences.

### DIFF
--- a/R/calculate_bias.R
+++ b/R/calculate_bias.R
@@ -136,7 +136,7 @@ calculate_bias <- function(x,
                           use_hyperprior = TRUE) {
 
   #convert x to SpatialPoints
-  dat.pts <- sp::SpatialPoints(x[, c("decimalLongitude", "decimalLatitude")])
+  # dat.pts <- sp::SpatialPoints(x[, c("decimalLongitude", "decimalLatitude")])
   dat.pts <- sp::SpatialPoints(x[, c("decimalLatitude", "decimalLongitude")])
 
   # create dummy raster if no raster is supplied

--- a/R/calculate_bias.R
+++ b/R/calculate_bias.R
@@ -137,10 +137,12 @@ calculate_bias <- function(x,
 
   #convert x to SpatialPoints
   dat.pts <- sp::SpatialPoints(x[, c("decimalLongitude", "decimalLatitude")])
+  dat.pts <- sp::SpatialPoints(x[, c("decimalLatitude", "decimalLongitude")])
 
   # create dummy raster if no raster is supplied
   if(!is.null(inp_raster)){
     dum.ras <- inp_raster
+	raster::projection(dat.pts) <- raster::projection(dum.ras)
   }else{
     dum.ras <- raster::raster(round(extent(dat.pts), .DecimalPlaces(res)))
     res(dum.ras) <- res


### PR DESCRIPTION
Hi Alexander,

I'm writing a vignette/supplement for the paper you, I, and lots of other folds are writing with Jamie K on SDM software.  I couldn't get calculate_bias to run using just a set of occurrences (no other arguments supplied), or with a template raster, etc. I found that the issue was that near the top of calculate_bias() longitude and latitude were being swapped when converting the occurrences to a SpatialPoints object.

I also added a line to transfer the raster's CRS to the points if a template raster is supplied.  Just for safety!

Thanks,
Adam